### PR TITLE
fix: clip periodInfo text on small window sizes

### DIFF
--- a/features/Header/components/PeriodInfo.tsx
+++ b/features/Header/components/PeriodInfo.tsx
@@ -122,7 +122,7 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
                 width={'22px'}
                 height={'22px'}
               />
-              <Flex alignItems={'center'} width={'100%'} paddingLeft={'8px'}>
+              <Flex alignItems={'center'} width={'95%'} paddingLeft={'8px'}>
                 <Text
                   fontWeight={'bold'}
                   fontSize={'14'}

--- a/features/Header/components/PeriodInfo.tsx
+++ b/features/Header/components/PeriodInfo.tsx
@@ -69,6 +69,7 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
   const next_period_start =
     current_period === 'posting' ? next_posting_start : next_voting_start;
   const next_period_start_time_left = momentLeft(next_period_start).toString();
+  
 
   return (
     <Menu>
@@ -128,6 +129,11 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
                   fontFamily="DM Sans"
                   color={current_period === 'posting' ? 'darkPurple' : 'green'}
                   paddingRight={'10px'}
+                  style={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis'
+                  }}
                 >
                   Current cycle:{' '}
                   {periodInfoQuery?.data
@@ -149,6 +155,11 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
                   fontFamily="DM Sans"
                   color={current_period === 'posting' ? 'midnight' : 'lilac'}
                   paddingLeft={'10px'}
+                  style={{
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis'
+                  }}
                 >
                   {periodInfoQuery?.data
                     ? `${next_period_start_time_left}`

--- a/features/Header/components/PeriodInfo.tsx
+++ b/features/Header/components/PeriodInfo.tsx
@@ -69,7 +69,7 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
   const next_period_start =
     current_period === 'posting' ? next_posting_start : next_voting_start;
   const next_period_start_time_left = momentLeft(next_period_start).toString();
-  
+
 
   return (
     <Menu>
@@ -124,21 +124,19 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
               />
               <Flex alignItems={'center'} width={'95%'} paddingLeft={'8px'}>
                 <Text
-                  fontWeight={'bold'}
-                  fontSize={'14'}
+                  fontWeight="bold"
+                  fontSize="14px"
                   fontFamily="DM Sans"
                   color={current_period === 'posting' ? 'darkPurple' : 'green'}
-                  paddingRight={'10px'}
-                  style={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
+                  paddingRight="10px"
+                  whiteSpace="nowrap"
+                  overflow="hidden"
+                  textOverflow="ellipsis"
                 >
                   Current cycle:{' '}
                   {periodInfoQuery?.data
                     ? (((current_period?.charAt(0).toUpperCase() as string) +
-                        current_period?.slice(1)) as string)
+                      current_period?.slice(1)) as string)
                     : ''}
                 </Text>
                 <Divider
@@ -150,20 +148,16 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
                   }
                 />
                 <Text
-                  fontWeight={'normal'}
-                  fontSize={'14'}
+                  fontWeight="normal"
+                  fontSize="14px"
                   fontFamily="DM Sans"
                   color={current_period === 'posting' ? 'midnight' : 'lilac'}
-                  paddingLeft={'10px'}
-                  style={{
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis'
-                  }}
+                  paddingLeft="10px"
+                  whiteSpace="nowrap"
+                  overflow="hidden"
+                  textOverflow="ellipsis"
                 >
-                  {periodInfoQuery?.data
-                    ? `${next_period_start_time_left}`
-                    : ''}
+                  {periodInfoQuery?.data ? `${next_period_start_time_left}` : ''}
                 </Text>
               </Flex>
             </Flex>
@@ -222,7 +216,7 @@ export default function PeriodInfo({ cosmWasmClient }: Props) {
               >
                 {current_period
                   ? current_period.charAt(0).toUpperCase() +
-                    current_period.slice(1)
+                  current_period.slice(1)
                   : ''}
               </Text>
             </Flex>


### PR DESCRIPTION
**Issue:**
On small window sizes the text in the PeriodInfo bleeds out of its container (see attached screenshot)
![Screenshot 2023-06-28 at 22 54 04](https://github.com/jmesworld/gov/assets/15247893/a6a6be31-b0d5-4a7a-8c61-97aa9d1966c5)


**Solution**
This PR updates the Text style within the PeriodInfo
![Screenshot 2023-06-28 at 23 00 12](https://github.com/jmesworld/gov/assets/15247893/71e7f40f-3724-4bec-96e7-69182e5524ae)
![Screenshot 2023-06-28 at 23 00 44](https://github.com/jmesworld/gov/assets/15247893/226487f1-5544-4092-8869-746600be66b5)
