### PR TITLE
Dao default voting threshold + threshold lower and upper bounds

### DIFF
--- a/features/Dao/CreateDaoForm.tsx
+++ b/features/Dao/CreateDaoForm.tsx
@@ -47,6 +47,8 @@ const fee: StdFee = {
   gas: '10000000',
 };
 
+const DEFAULT_DAO_THRESHOLD = 100; // 100% threshold by default
+
 const CreateDaoForm = ({
   setCreateDaoSelected,
   daoOwner,
@@ -59,7 +61,7 @@ const CreateDaoForm = ({
 
   const [daoName, setDaoName] = useState('');
   const [daoMembers, setDaoMembers] = useState([daoOwner]);
-  const [threshold, setThreshold] = useState(50);
+  const [threshold, setThreshold] = useState(DEFAULT_DAO_THRESHOLD);
   const [isIdentityNamesValid, setIdentityNamesValid] = useState(false);
   const [focusedCosignerIndex, setFocusedCosignerIndex] = useState(Infinity);
   const [isCreatingDao, setIsCreatingDao] = useState(false);
@@ -451,7 +453,7 @@ const CreateDaoForm = ({
       </Text>
       <Slider
         aria-label="dao-proposal-threshold"
-        defaultValue={50}
+        defaultValue={DEFAULT_DAO_THRESHOLD}
         width={'722px'}
         onChange={val => setThreshold(val)}
       >

--- a/features/Dao/CreateDaoForm.tsx
+++ b/features/Dao/CreateDaoForm.tsx
@@ -456,6 +456,9 @@ const CreateDaoForm = ({
         defaultValue={DEFAULT_DAO_THRESHOLD}
         width={'722px'}
         onChange={val => setThreshold(val)}
+        min={1}
+        max={100}
+        step={1}
       >
         <SliderTrack
           height={'16px'}


### PR DESCRIPTION
This PR introduces:

1. Dao default voting threshold -  100%
2. Lower and Upper bounds for the voting threshold - 1% and 100%, respectively.